### PR TITLE
Update workbox-webpack-plugin from version 6.1.5 to 6.2.0 

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -73,7 +73,7 @@
     "webpack": "5.41.1",
     "webpack-dev-server": "4.0.0-rc.0",
     "webpack-manifest-plugin": "3.1.1",
-    "workbox-webpack-plugin": "6.1.5"
+    "workbox-webpack-plugin": "6.2.0"
   },
   "devDependencies": {
     "react": "^17.0.1",


### PR DESCRIPTION
there were some updates on workbox-webpack-plugin for webpack 5 and module . This PR upgrades the dependency to its last version.

Currently react-scripts is using workbox-webpack-plugin=6.1.5 , this seems to cause to cause some problems and those problems were fixed in the last version of the plugin. With this PR we aim to upgrade the dependency to the latest version to 6.2.0 and resolve those issues.

#11293 